### PR TITLE
Enable IdP to manage group memberships after initial user creation

### DIFF
--- a/authsaml/auth.php
+++ b/authsaml/auth.php
@@ -37,6 +37,7 @@ class auth_plugin_authsaml extends DokuWiki_Auth_Plugin
 
         // $this->cando['external'] = true;
 
+        $this->cando['modGroups'] = true;
         $this->cando['external'] = true;
         $this->cando['logoff'] = true;
         $this->success = true;

--- a/authsaml/saml.php
+++ b/authsaml/saml.php
@@ -369,8 +369,8 @@ class saml_handler {
             $userinfo[$field] = $value;
         }
 
-        $groups   = join(',', $userinfo['grps']);
-        $groups   = array_map('urlencode', $groups);
+        $groups   = array_map('urlencode', $userinfo['grps']);
+        $groups   = join(',', $groups);
 
         $userline = join(':', array($newuser, $userinfo['name'], $userinfo['mail'], $groups))."\n";
 


### PR DESCRIPTION
This PR contains two parts:

- A bug fix preventing group modification to work properly (modifyUser was trying to run array_map on a string)
- Enabling the modGroups flag in cando.

This will address issue #8 