### PR TITLE
Refactor register/update logic from action_plugin_authsaml::handle_login to saml_handler::login

### DIFF
--- a/authsaml/action.php
+++ b/authsaml/action.php
@@ -66,23 +66,7 @@ class action_plugin_authsaml extends DokuWiki_Action_Plugin
             }
 
             if ($this->saml->ssp->isAuthenticated()) {
-
                 $username = $this->saml->getUsername();
-
-                $user = $this->saml->getUserData($username);
-
-                if(!$user) {
-                    if(!$this->saml->register_user($username)) {
-                        $auth->sucess = false;
-                        //Exception error creating
-                    }
-                    else {
-                        $user = $this->saml->getUserData($username);
-                    }
-                }
-                else {
-                    $this->saml->update_user($username);
-                }
                 $this->saml->login($username);
             }
         }

--- a/authsaml/auth.php
+++ b/authsaml/auth.php
@@ -75,8 +75,7 @@ class auth_plugin_authsaml extends DokuWiki_Auth_Plugin
 
         if ($this->saml->ssp->isAuthenticated()) {
             $username = $this->saml->getUsername();
-            $this->saml->login($username);
-            return true;
+            return $this->saml->login($username);
         }
 
         return false;

--- a/authsaml/saml.php
+++ b/authsaml/saml.php
@@ -321,7 +321,7 @@ class saml_handler {
           msg('Error saving user data (2)', -1);
           return false;
         }
-        $this->users[$username] = $userinfo;
+        $this->users[$username] = $userData;
         return true;
     }
 

--- a/authsaml/saml.php
+++ b/authsaml/saml.php
@@ -175,6 +175,19 @@ class saml_handler {
 
             $userData = $this->getUserData($username);
 
+            if(!$userData) {
+                if(!$this->register_user($username)) {
+                    return false;
+                }
+            }
+            else {
+                if(!$this->update_user($username)) {
+                    return false;
+                }
+            }
+
+            $userData = $this->getUserData($username);
+
             $USERINFO['name'] = $userData['name'];
             $USERINFO['mail'] = $userData['mail'];
             $USERINFO['grps'] = $userData['grps'];
@@ -194,6 +207,7 @@ class saml_handler {
             $_SESSION[DOKU_COOKIE]['auth']['buid'] = auth_browseruid();
             $_SESSION[DOKU_COOKIE]['auth']['info'] = $USERINFO;
             $_SESSION[DOKU_COOKIE]['auth']['time'] = time();
+            return true;
         }
     }
 


### PR DESCRIPTION
Fixed cases where automatic registration / user updates don't happen when user is logged in through force_saml_login, by cleaning up code so registration/updates always happen on login always happens no matter how the login was reached.

Also found and fixed a bug where the $this->users cache in action_plugin_authsaml was incorrectly updated.