### PR TITLE
Change update_user to properly return success/failure

### DIFF
--- a/authsaml/saml.php
+++ b/authsaml/saml.php
@@ -259,11 +259,13 @@ class saml_handler {
 
         if (!empty($changes)) {
             if ($this->use_internal_user_store) {
-                $auth->modifyUser($username, $changes);
+                return $auth->modifyUser($username, $changes);
             }
             else {
-                $this->modifyUser($username, $changes);
+                return $this->modifyUser($username, $changes);
             }
+        } else {
+            return true;
         }
     }
 


### PR DESCRIPTION
Hi!

Unfortunately, #18 wasn't quite complete. It relied on update_user returning true/false status which it doesn't. So with the code in the previous PR it only works on new registration. (oops)