### PR TITLE
Improvements to login form

### DIFF
--- a/authsaml/action.php
+++ b/authsaml/action.php
@@ -95,7 +95,7 @@ class action_plugin_authsaml extends DokuWiki_Action_Plugin
         }
 
         $fieldset  = '<fieldset height="400px" style="margin-bottom:20px;"><legend padding-top:-5px">'.$this->getLang('saml_connect').'</legend>';
-        $fieldset .= '<center><a href="'.$this->saml->ssp->getLoginURL().'"><img src="lib/plugins/authsaml/logo.gif" alt="uniquid - saml"></a><br>';
+        $fieldset .= '<center><a href="'.$this->saml->ssp->getLoginURL().'"><img src="'.getBaseURL().'lib/plugins/authsaml/logo.gif" alt="uniquid - saml"></a><br>';
         $fieldset .= $this->getLang('login_link').'</center></fieldset>';
         $event->data->insertElement(0, $fieldset);
     }

--- a/authsaml/action.php
+++ b/authsaml/action.php
@@ -86,6 +86,14 @@ class action_plugin_authsaml extends DokuWiki_Action_Plugin
 
         $this->saml->get_ssp_instance();
 
+        $force_saml_login = $this->getConf('force_saml_login');
+        if ($force_saml_login) {
+            /* if we're forcing SAML login, get rid of the existing login form. yes this is a pretty ugly way of deleting the form but this is what's possible given the dokuwiki API... */
+            while($event->data->getElementAt(0)) {
+            $event->data->replaceElement(0, null);
+            }
+        }
+
         $fieldset  = '<fieldset height="400px" style="margin-bottom:20px;"><legend padding-top:-5px">'.$this->getLang('saml_connect').'</legend>';
         $fieldset .= '<center><a href="'.$this->saml->ssp->getLoginURL().'"><img src="lib/plugins/authsaml/logo.gif" alt="uniquid - saml"></a><br>';
         $fieldset .= $this->getLang('login_link').'</center></fieldset>';

--- a/authsaml/action.php
+++ b/authsaml/action.php
@@ -89,8 +89,7 @@ class action_plugin_authsaml extends DokuWiki_Action_Plugin
         $fieldset  = '<fieldset height="400px" style="margin-bottom:20px;"><legend padding-top:-5px">'.$this->getLang('saml_connect').'</legend>';
         $fieldset .= '<center><a href="'.$this->saml->ssp->getLoginURL().'"><img src="lib/plugins/authsaml/logo.gif" alt="uniquid - saml"></a><br>';
         $fieldset .= $this->getLang('login_link').'</center></fieldset>';
-        $pos = $event->data->findElementByAttribute('type', 'submit');
-        $event->data->insertElement($pos-4, $fieldset);
+        $event->data->insertElement(0, $fieldset);
     }
 
 }

--- a/authsaml/action.php
+++ b/authsaml/action.php
@@ -90,7 +90,7 @@ class action_plugin_authsaml extends DokuWiki_Action_Plugin
         if ($force_saml_login) {
             /* if we're forcing SAML login, get rid of the existing login form. yes this is a pretty ugly way of deleting the form but this is what's possible given the dokuwiki API... */
             while($event->data->getElementAt(0)) {
-            $event->data->replaceElement(0, null);
+                $event->data->replaceElement(0, null);
             }
         }
 


### PR DESCRIPTION
1. Cleaned-up logic for adding login button, make it simple but just adding the login button to the top of the form.
2. Add feature which removes the username/password login form when force_saml_login is enabled
3. Fix bug where login button image was not correctly displayed if login URL is shown inside a namespace e.g. http://wiki.example.com/namespace/start